### PR TITLE
Enable utf8 option of formatters when version equals minimum-allowed version

### DIFF
--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -199,7 +199,7 @@ sub _have_groff_with_utf8 {
 			 );
 		}
 
-	$version gt $minimum_groff_version;
+	$version ge $minimum_groff_version;
 	}
 
 sub _have_mandoc_with_utf8 {
@@ -224,7 +224,7 @@ sub _have_mandoc_with_utf8 {
 			 );
 		}
 
-	$version gt $minimum_mandoc_version;
+	$version ge $minimum_mandoc_version;
 	}
 
 sub _collect_nroff_switches {


### PR DESCRIPTION
Should return true if $version is equal to $minimum_*_version.
