### PR TITLE
Fix nroff switches detection regexp 

### DIFF
--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -298,7 +298,7 @@ sub _filter_through_nroff {
     # Maybe someone set rendering switches as part of the opt_n value
     # Deal with that here.
 
-    my ($render, $switches) = $self->__nroffer() =~ /\A([\/a-zA-Z0-9_-]+)\b(.+)?\z/;
+    my ($render, $switches) = $self->__nroffer() =~ /\A([\/a-zA-Z0-9_\.-]+)\b(.+)?\z/;
 
     $self->die("no nroffer!?") unless $render;
     my @render_switches = $self->_collect_nroff_switches;


### PR DESCRIPTION
if the path to the nroff command includes a dot (like $HOME/.homebrew/bin on
some Mac's) the regexp would fail and break the command path into two parts.
