### PR TITLE
Fix INSTALLDIRS for perl 5.12+

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -46,7 +46,7 @@ WriteMakefile(
 
     'MAN1PODS' => { 'perldoc.pod' => 'blib/man1/perldoc.1' },
 
-    ($^V >= 5.008001 ? ( 'INSTALLDIRS'  => 'perl' ) : ()),
+    'INSTALLDIRS' => ( ( $] >= 5.008001 && $] < 5.012 ) ? 'perl' : 'site' ),
 
     ( $EUMM_VERSION > 6.31 ? (
         'LICENSE' => 'perl',


### PR DESCRIPTION
From [rt.perl.org #116479](https://rt.perl.org/rt3/Ticket/Display.html?id=116479):

> Historically, dual-life modules have upgraded to the "perl"/"core" installdirs (as opposed to site, where most modules go). This kind of made sense before 5.12, when we made sense out of our default loading order, but really doesn't anymore right now. We should make all dual life modules install to site when installed from CPAN on 5.12+.
