### PR TITLE
Document -U and make it implied with -F RT#87837

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Pod::Perldoc
 
+next-ver
+    * -U now documented and implied with -F (RT#87837)
+
 3.25 - Thu Feb 12 03:06:43 UTC 2015
     * No changes - roll an official
       release for inclusion in Perl 5.22

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -283,7 +283,8 @@ Options:
     -m   Display module's file in its entirety
     -n   Specify replacement for groff
     -l   Display the module's file name
-    -F   Arguments are file names, not modules
+    -U   Don't attempt to drop privs for security
+    -F   Arguments are file names, not modules (implies -U)
     -D   Verbosely describe what's going on
     -T   Send output to STDOUT without any pager
     -d output_filename_to_send_to
@@ -391,7 +392,7 @@ sub usage_brief {
   my $program_name = $self->program_name;
 
   CORE::die( <<"EOUSAGE" );
-Usage: $program_name [-hVriDtumFXlT] [-n nroffer_program]
+Usage: $program_name [-hVriDtumUFXlT] [-n nroffer_program]
     [-d output_filename] [-o output_format] [-M FormatterModule]
     [-w formatter_option:option_value] [-L translation_code]
     PageName|ModuleName|ProgramName
@@ -519,7 +520,7 @@ sub process {
     $self->options_reading;
     $self->pagers_guessing;
     $self->aside(sprintf "$0 => %s v%s\n", ref($self), $self->VERSION);
-    $self->drop_privs_maybe unless $self->opt_U;
+    $self->drop_privs_maybe unless ($self->opt_U || $self->opt_F);
     $self->options_processing;
 
     # Hm, we have @pages and @found, but we only really act on one

--- a/perldoc.pod
+++ b/perldoc.pod
@@ -5,7 +5,7 @@ perldoc - Look up Perl documentation in Pod format.
 
 =head1 SYNOPSIS
 
-    perldoc [-h] [-D] [-t] [-u] [-m] [-l] [-F]
+    perldoc [-h] [-D] [-t] [-u] [-m] [-l] [-U] [-F]
         [-i] [-V] [-T] [-r]
         [-d destination_file]
         [-o formatname]
@@ -78,9 +78,13 @@ the file for you and simply hand it off for display.
 
 Display onB<l>y the file name of the module found.
 
+=item B<-U>
+
+Don't attempt drop privs for security. This option is implied with B<-F>.
+
 =item B<-F>
 
-Consider arguments as file names; no search in directories will be performed.
+Consider arguments as file names; no search in directories will be performed. Implies B<-U>.
 
 =item B<-f> I<perlfunc>
 


### PR DESCRIPTION
The already existing but undocumented perldoc -U option has now been
added to official POD/usage docs. Also, this option is now implied when
using -F (args as file names), since -F will rarely if ever work without
-U (since it is unlikely a given file/path will still be readable after
drop privs), which is very unexpected behavior.