### PR TITLE
Fall back to english perlfunc if translations does not exist RT#104695

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1320,7 +1320,7 @@ sub search_perlfunc {
     local $_;
     while (<$fh>) {
         /^=encoding\s+(\S+)/ && $self->set_encoding($fh, $1);
-        last if /^=head2 $re/;
+        last if /^=head2 (?:$re|Alphabetical Listing of Perl Functions)/;
     }
 
     # Look for our function


### PR DESCRIPTION
This PR should fix [RT#104695](https://rt.cpan.org/Ticket/Display.html?id=104695).
It changes the regex match as proposed in the ticket.

I've tested it with POD2::ES (no perlfunc translation) and POD2::IT (has perlfunc translation)