### PR TITLE
CVE-2016-1238: avoid loading optional modules from default .

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -576,6 +576,9 @@ sub find_good_formatter_class {
   my @class_list = @{ $self->{'formatter_classes'} || [] };
   $self->die( "WHAT?  Nothing in the formatter class list!?" ) unless @class_list;
 
+  local @INC = @INC;
+  pop @INC if $INC[-1] eq '.';
+
   my $good_class_found;
   foreach my $c (@class_list) {
     DEBUG > 4 and print "Trying to load $c...\n";
@@ -1007,6 +1010,8 @@ sub new_translator { # $tr = $self->new_translator($lang);
     my $self = shift;
     my $lang = shift;
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     my $pack = 'POD2::' . uc($lang);
     eval "require $pack";
     if ( !$@ && $pack->can('new') ) {


### PR DESCRIPTION
Pod::Perldoc attempts to load various modules optionally, which
with perl's default . at the end of @INC, if a user runs perldoc
in a world-writable directory such as /tmp, an attacker
can create that module under /tmp to run code as the user of
perldoc.

The attached patch avoids two instances of this in Pod::Perldoc by
temporarily removing the default . from the end of @INC.