### PR TITLE
RT #116601 and RT #116551 Test invokes wrong perldoc

### DIFF
--- a/t/02_module_pod_output.t
+++ b/t/02_module_pod_output.t
@@ -12,7 +12,7 @@ my $stderr = undef;
 
 # get path to perldoc exec in a hopefully platform neutral way..
 my ($volume, $bindir, undef) = File::Spec->splitpath($Bin);
-my $perldoc = File::Spec->catpath($volume,$bindir,"perldoc");
+my $perldoc = File::Spec->catpath($volume,$bindir, File::Spec->catfile(qw(blib script perldoc)));
 my @dir = ($bindir,"lib","Pod");
 my $podpath = File::Spec->catdir(@dir);
 my $good_podfile = File::Spec->catpath($volume,$podpath,"Perldoc.pm");


### PR DESCRIPTION
Test invokes `perldoc` in source directory, rather than
`blib/script/perldoc`.

This causes two problems:

1. The test fails on Windows because the whole hash-bang mechanism for
running programs does not work on that platform. This is the problem
reported in RT #116551

2. More subtly, but equally importantly, the test uses `/usr/bin/perl`
and *NOT* the `perl` with which the module is being built.