### PR TITLE
Consider the formatter and operating system before modifying environment variables

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1931,6 +1931,8 @@ sub page {  # apply a pager to the output file
             $self->aside("About to try calling $pager $output\n");
             if ($self->is_vms) {
                 last if system("$pager $output") == 0;
+	    } elsif($self->is_mswin32) {
+                last if system("$pager $output") == 0;
 	    } elsif($self->is_amigaos) { 
                 last if system($pager, $output) == 0;
             } else {

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1932,7 +1932,7 @@ sub page {  # apply a pager to the output file
             if ($self->is_vms) {
                 last if system("$pager $output") == 0;
 	    } elsif($self->is_mswin32) {
-                last if system("$pager $output") == 0;
+                last if system("$pager \"$output\"") == 0;
 	    } elsif($self->is_amigaos) { 
                 last if system($pager, $output) == 0;
             } else {


### PR DESCRIPTION
Before any modifications occur to environment variable settings for pagers like `less` or `more`, consider the formatter class and the operating system.

Only modify the pager environment when the formatter is `ToTerm` and the operating system is not windows or dos.

Incorporates and supersedes #30. 

Addresses RT#116953.