### PR TITLE
Add message about SSL library if SSL URL

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -851,8 +851,11 @@ sub grand_search_init {
                    =~ s/\.P(?:[ML]|OD)\z//;
             }
             else {
-                print STDERR "No " .
+              print STDERR "No " .
                     ($self->opt_m ? "module" : "documentation") . " found for \"$_\".\n";
+              if ( /^https/ ) {
+                print STDERR "You may need an SSL library (such as IO::Socket::SSL) for that URL.\n";
+              }
             }
             next;
         }


### PR DESCRIPTION
RT#107874 suggests that an additional message about possibly needing an SSL library if a document could not be retrieved is a good one. This addresses that suggestion.