### PR TITLE
CHANGE: files are judged as pod-containing if they have either a =pod or a =head tag.

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1813,7 +1813,7 @@ sub containspod {
     local($_);
     my $fh = $self->open_fh("<", $file);
     while (<$fh>) {
-    if (/^=head/) {
+    if (/^=(head|pod)/) {
         close($fh)     or $self->die( "Can't close $file: $!" );
         return 1;
     }


### PR DESCRIPTION
…re checked to see if they seem to be pod-containing.  PREVIOUSLY, a file needed to have a =head tag to be considered as pod-containing.  CHANGE: files are judged as pod-containing if they have either a =pod or a =head tag.