### PR TITLE
Conditionally restore ToMan functionality

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -608,7 +608,10 @@ sub init_formatter_class_list {
 
 	if ( my ($less_bin) = grep /less/, $self->pagers ) {
 	  my $minimum = '346'; # added between 340 and 346
-      my $version_string = `$less_bin --version`;
+      # The less binary can have shell redirection characters
+      # So we're cleaning that up and everything afterwards
+      my ($less_bin_clean) = $less_bin =~ /^([^<>]+)/;
+      my $version_string = `$less_bin_clean --version`;
       my( $version ) = $version_string =~ /less (\d+)/;
 
       $version ge $minimum

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -70,6 +70,9 @@ BEGIN {
  *is_linux   = $^O eq 'linux'   ? \&TRUE : \&FALSE unless defined &is_linux;
  *is_hpux    = $^O =~ m/hpux/   ? \&TRUE : \&FALSE unless defined &is_hpux;
  *is_amigaos = $^O eq 'amigaos' ? \&TRUE : \&FALSE unless defined &is_amigaos;
+ *is_openbsd = $^O =~ m/openbsd/ ? \&TRUE : \&FALSE unless defined &is_openbsd;
+ *is_freebsd = $^O =~ m/freebsd/ ? \&TRUE : \&FALSE unless defined &is_freebsd;
+ *is_bitrig = $^O =~ m/bitrig/ ? \&TRUE : \&FALSE unless defined &is_bitrig;
 }
 
 $Temp_File_Lifetime ||= 60 * 60 * 24 * 5;

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -606,8 +606,10 @@ sub init_formatter_class_list {
 	# We can only know if it's one of the detected pagers
 	# (there could be others that would be tried)
 
-	if ( my ($less_bin) = grep /less/, $self->pagers ) {
+	if ( my @less_bins = grep /less/, $self->pagers ) {
 	  my $minimum = '346'; # added between 340 and 346
+
+    foreach my $less_bin (@less_bins) {
       # The less binary can have shell redirection characters
       # So we're cleaning that up and everything afterwards
       my ($less_bin_clean) = $less_bin =~ /^([^<>]+)/;
@@ -617,6 +619,7 @@ sub init_formatter_class_list {
       $version ge $minimum
         and return $self->opt_o_with('term');
     }
+  }
   }
 
   # No fallback listed here, which means we will use ToText

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -582,13 +582,14 @@ sub init_formatter_class_list {
   # but do *not* instantiate them yet, despite the subroutine name!
   $self->opt_M_with('Pod::Perldoc::ToPod');   # the always-there fallthru
   $self->opt_o_with('text');
-  $self->opt_o_with('term')
-    unless $self->is_mswin32 || $self->is_dos || $self->is_amigaos
-       || !($ENV{TERM} && (
-              ($ENV{TERM} || '') !~ /dumb|emacs|none|unknown/i
-           ));
 
-  return;
+  $self->is_mswin32 || $self->is_dos || $self->is_amigaos
+    and return;
+
+  ( $ENV{TERM} || '' ) =~ /dumb|emacs|none|unknown/i
+	and return;
+
+  $self->opt_o_with('term');
 }
 
 #..........................................................................

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -609,7 +609,7 @@ sub init_formatter_class_list {
 	if ( my ($less_bin) = grep /less/, $self->pagers ) {
 	  my $minimum = '346'; # added between 340 and 346
       my $version_string = `$less_bin --version`;
-      my( $version ) = $version_string =~ /\(?groff\)? version (\d+\.\d+(?:\.\d+)?)/;
+      my( $version ) = $version_string =~ /less (\d+)/;
 
       $version ge $minimum
         and return $self->opt_o_with('term');

--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -454,12 +454,13 @@ sub init {
 
   $self->{'target'} = undef;
   $self->{'executables'} = $self->inspect_execs();
-  $self->init_formatter_class_list;
 
   $self->{'pagers' } = [@Pagers] unless exists $self->{'pagers'};
   $self->{'bindir' } = $Bindir   unless exists $self->{'bindir'};
   $self->{'pod2man'} = $Pod2man  unless exists $self->{'pod2man'};
   $self->{'search_path'} = [ ]   unless exists $self->{'search_path'};
+
+  $self->init_formatter_class_list;
 
   push @{ $self->{'formatter_switches'} = [] }, (
    # Yeah, we could use a hashref, but maybe there's some class where options

--- a/lib/Pod/Perldoc/BaseTo.pm
+++ b/lib/Pod/Perldoc/BaseTo.pm
@@ -32,6 +32,7 @@ BEGIN {
  *is_cygwin  = $^O eq 'cygwin'   ? \&TRUE : \&FALSE unless defined &is_cygwin;
  *is_linux   = $^O eq 'linux'    ? \&TRUE : \&FALSE unless defined &is_linux;
  *is_hpux    = $^O =~ m/hpux/    ? \&TRUE : \&FALSE unless defined &is_hpux;
+ *is_amigaos = $^O eq 'amigaos' ? \&TRUE : \&FALSE unless defined &is_amigaos;
  *is_openbsd = $^O =~ m/openbsd/ ? \&TRUE : \&FALSE unless defined &is_openbsd;
  *is_freebsd = $^O =~ m/freebsd/ ? \&TRUE : \&FALSE unless defined &is_freebsd;
  *is_bitrig = $^O =~ m/bitrig/ ? \&TRUE : \&FALSE unless defined &is_bitrig;

--- a/lib/Pod/Perldoc/BaseTo.pm
+++ b/lib/Pod/Perldoc/BaseTo.pm
@@ -69,33 +69,6 @@ sub die {
 	croak join "\n", @messages, '';
 	}
 
-sub _get_path_components {
-	my( $self ) = @_;
-
-	my @paths = split /\Q$Config{path_sep}/, $ENV{PATH};
-
-	return @paths;
-	}
-
-sub _find_executable_in_path {
-	my( $self, $program ) = @_;
-
-	my @found = ();
-	foreach my $dir ( $self->_get_path_components ) {
-		my $binary = catfile( $dir, $program );
-		$self->debug( "Looking for $binary\n" );
-		next unless -e $binary;
-		unless( -x $binary ) {
-			$self->warn( "Found $binary but it's not executable. Skipping.\n" );
-			next;
-			}
-		$self->debug( "Found $binary\n" );
-		push @found, $binary;
-		}
-
-	return @found;
-	}
-
 1;
 
 __END__

--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -47,50 +47,10 @@ sub new {
 
 sub init {
 	my( $self, @args ) = @_;
-
-	unless( $self->__nroffer ) {
-		my $roffer = $self->_find_roffer( $self->_roffer_candidates );
-		$self->debug( "Using $roffer\n" );
-		$self->__nroffer( $roffer );
-		}
-    else {
-	    $self->debug( "__nroffer is " . $self->__nroffer() . "\n" );
-        }
-
-	$self->_check_nroffer;
-	}
-
-sub _roffer_candidates {
-	my( $self ) = @_;
-
-	if( $self->is_openbsd || $self->is_freebsd || $self->is_bitrig ) { qw( mandoc groff nroff ) }
-	else                    { qw( groff nroff mandoc ) }
-	}
-
-sub _find_roffer {
-	my( $self, @candidates ) = @_;
-
-	my @found = ();
-	foreach my $candidate ( @candidates ) {
-		push @found, $self->_find_executable_in_path( $candidate );
-		}
-
-	return wantarray ? @found : $found[0];
-	}
-
-sub _check_nroffer {
-	return 1;
-	# where is it in the PATH?
-
-	# is it executable?
-
-	# what is its real name?
-
-	# what is its version?
-
-	# does it support the flags we need?
-
-	# is it good enough for us?
+    # We used to print the __nroffer here, but we can't anymore
+    # Because it only gets applied after the new() and init() calls
+    # Check Pod::Perldoc::render_findings() (under formatter_switches)
+    #$self->debug( "__nroffer is " . $self->__nroffer() . "\n" );
 	}
 
 sub _get_stty { `stty -a` }


### PR DESCRIPTION
[Each commit here has been done separately with - hopefully - a good commit message. It is easier to review them separately than together.]

This Pull Request introduces ToMan back and provides conditions for when to use ToMan and when to use ToTerm, falling back to ToText (as before).

The conditions are as follows (or should be):

* If `groff` is new enough, use ToMan. This was the previous system that was moved to ToTerm but worked well for non-macOS operating systems. ToTerm works well for those Macs but fails any non-macOS. macOS carries an older version of `groff`.
* If `groff` is too old (macOS) and our pager is `less`, use ToTerm. ToTerm will continue to (conditionally) set the `-R` to make `less` work well.
* If groff is too old and our pager is not `less`, use ToText. This is the fallback and was set before our code for deciding whetther to use ToMan or ToTerm.

Thee way this PR works is by moving the detection of `groff` to the main module (and hopefully refactoring it to allow other stuff in the future) and then making the decision in line 593 and below in Perldoc.pm.

This should resolve [RT#120229](https://rt.cpan.org/Public/Bug/Display.html?id=120229).
