### PR TITLE
Mandoc supports UTF-8 since 2011

### DIFF
--- a/lib/Pod/Perldoc/ToMan.pm
+++ b/lib/Pod/Perldoc/ToMan.pm
@@ -209,12 +209,6 @@ sub _have_groff_with_utf8 {
 	$version ge $minimum_groff_version;
 	}
 
-sub _have_mandoc_with_utf8 {
-	my( $self ) = @_;
-
-       $self->_is_mandoc and not system 'mandoc -Tlocale -V > /dev/null 2>&1';
-	}
-
 sub _collect_nroff_switches {
 	my( $self ) = shift;
 
@@ -242,7 +236,6 @@ sub _get_device_switches {
 	   if( $self->_is_nroff  )             { qw()              }
 	elsif( $self->_have_groff_with_utf8 )  { qw(-Kutf8 -Tutf8) }
 	elsif( $self->_is_ebcdic )             { qw(-Tcp1047)      }
-	elsif( $self->_have_mandoc_with_utf8 ) { qw(-Tlocale)      }
 	elsif( $self->_is_mandoc )             { qw()              }
 	else                                   { qw(-Tlatin1)      }
 	}


### PR DESCRIPTION
The -Tlocale option has been the default since 2014 (and will remain the
default) while the -V option was removed in 2015 and won't come back.

All operating systems having a mandoc port or package ship a version
that is recent enough that UTF-8 just works, so testing for this is
unnecessary. Moreover, the actual feature test is broken since it would
only succeed on very outdated mandoc installations.